### PR TITLE
Adding creation of menu entry:

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,21 @@
     tags:
       - pycharm-install-new
 
+- name: determine path and name of pycharm installation directory
+  shell: "ls {{ pycharm_install_prefix }} | grep pycharm"
+  register: lscontents
+
+- set_fact: pycharm_install_dirname="{{ lscontents.stdout }}"
+
+- name: install IntelliJ IDEA desktop file
+  become: yes
+  template:
+    src: jetbrains-pycharm.desktop.j2
+    dest: '/usr/share/applications/jetbrains-pycharm-{{ pycharm_edition }}.desktop'
+    owner: root
+    group: root
+    mode: 'u=rw,go=r'
+
   tags:
     - configuration
     - pycharm

--- a/templates/jetbrains-pycharm.desktop.j2
+++ b/templates/jetbrains-pycharm.desktop.j2
@@ -1,0 +1,13 @@
+{{ ansible_managed | comment }}
+
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=pycharm-{{ pycharm_edition }}
+Icon={{ pycharm_install_prefix}}/{{ pycharm_install_dirname }}/bin/pycharm.png
+Exec="{{ pycharm_install_prefix}}/{{ pycharm_install_dirname }}/bin/pycharm.sh" %f
+Comment=Develop with pleasure!
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=PyCharm
+


### PR DESCRIPTION
- menu entry is now created during the installation
- determining of directory name and setting as fact is necessary, because in default case the edition is "professional", but the directory name is just "pycharm-{{ version }}"